### PR TITLE
Unicode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ You can calculate winning cards in Five hundred tricks.
       trump: Suit.clubs,
     ))
     # => Card.from_string("10S")
+
+There are also silly monkeypatches you probably don't want to use in real life, but make for fun READMEs.
+
+    require 'card_game/core_ext'
+
+    FiveHundred.winning_card(Trick.new(
+      cards: [ "A".♡, 5.♢, 10.♧, "A".♢ ],
+      trump: Suit.♢,
+    ))
+    # => Card.from_string("AD")

--- a/lib/card_game/core_ext.rb
+++ b/lib/card_game/core_ext.rb
@@ -1,0 +1,50 @@
+require 'card_game/card'
+
+module CardGame
+  # These are silly monkeypatches that you probably don't want to use in real life
+  module CoreExt
+    # @return [Card]
+    def hearts
+      CardGame::Card.from_string("#{self}H")
+    end
+
+    alias_method :♡, :hearts
+    alias_method :♥︎, :hearts
+    alias_method :♥️︎, :hearts
+
+    # @return [Card]
+    def diamonds
+      CardGame::Card.from_string("#{self}D")
+    end
+
+    alias_method :♢, :diamonds
+    alias_method :♦︎, :diamonds
+    alias_method :♦️, :diamonds
+
+    # @return [Card]
+    def clubs
+      CardGame::Card.from_string("#{self}C")
+    end
+
+    alias_method :♧, :clubs
+    alias_method :♣︎, :clubs
+    alias_method :♣️, :clubs
+
+    # @return [Card]
+    def spades
+      CardGame::Card.from_string("#{self}S")
+    end
+
+    alias_method :♤, :spades
+    alias_method :♠︎, :spades
+    alias_method :♠️︎, :spades
+  end
+end
+
+class String
+  include CardGame::CoreExt
+end
+
+class Integer
+  include CardGame::CoreExt
+end

--- a/lib/card_game/suit.rb
+++ b/lib/card_game/suit.rb
@@ -33,6 +33,24 @@ module CardGame
     # @return [Suit]
     def self.none;     Suit.new(symbol: "",   color: Color.none) end
 
+    class << self
+      alias_method :♡, :hearts
+      alias_method :♥︎, :hearts
+      alias_method :♥️︎, :hearts
+
+      alias_method :♢, :diamonds
+      alias_method :♦︎, :diamonds
+      alias_method :♦️, :diamonds
+
+      alias_method :♧, :clubs
+      alias_method :♣︎, :clubs
+      alias_method :♣️, :clubs
+
+      alias_method :♤, :spades
+      alias_method :♠︎, :spades
+      alias_method :♠️︎, :spades
+    end
+
     # All suits, including +none+.
     # @return [Array<Suit>]
     def self.all

--- a/spec/unit/card_game/core_ext_spec.rb
+++ b/spec/unit/card_game/core_ext_spec.rb
@@ -1,0 +1,51 @@
+require 'card_game/core_ext'
+
+describe CardGame::CoreExt, aggregate_failures: true do
+  describe 'String' do
+    it 'points to the right things' do
+      expect("A".hearts).to eq(CardGame::Card.from_string("AH"))
+      expect("A".♡).to eq(CardGame::Card.from_string("AH"))
+      expect("A".♥︎).to eq(CardGame::Card.from_string("AH"))
+      expect("A".♥️︎).to eq(CardGame::Card.from_string("AH"))
+
+      expect("K".diamonds).to eq(CardGame::Card.from_string("KD"))
+      expect("K".♢).to eq(CardGame::Card.from_string("KD"))
+      expect("K".♦︎).to eq(CardGame::Card.from_string("KD"))
+      expect("K".♦️).to eq(CardGame::Card.from_string("KD"))
+
+      expect("Q".clubs).to eq(CardGame::Card.from_string("QC"))
+      expect("Q".♧).to eq(CardGame::Card.from_string("QC"))
+      expect("Q".♣︎).to eq(CardGame::Card.from_string("QC"))
+      expect("Q".♣️).to eq(CardGame::Card.from_string("QC"))
+
+      expect("J".spades).to eq(CardGame::Card.from_string("JS"))
+      expect("J".♤).to eq(CardGame::Card.from_string("JS"))
+      expect("J".♠︎).to eq(CardGame::Card.from_string("JS"))
+      expect("J".♠️︎).to eq(CardGame::Card.from_string("JS"))
+    end
+  end
+
+  describe 'Integer' do
+    it 'points to the right things' do
+      expect(3.hearts).to eq(CardGame::Card.from_string("3H"))
+      expect(3.♡).to eq(CardGame::Card.from_string("3H"))
+      expect(3.♥︎).to eq(CardGame::Card.from_string("3H"))
+      expect(3.♥️︎).to eq(CardGame::Card.from_string("3H"))
+
+      expect(5.diamonds).to eq(CardGame::Card.from_string("5D"))
+      expect(5.♢).to eq(CardGame::Card.from_string("5D"))
+      expect(5.♦︎).to eq(CardGame::Card.from_string("5D"))
+      expect(5.♦️).to eq(CardGame::Card.from_string("5D"))
+
+      expect(7.clubs).to eq(CardGame::Card.from_string("7C"))
+      expect(7.♧).to eq(CardGame::Card.from_string("7C"))
+      expect(7.♣︎).to eq(CardGame::Card.from_string("7C"))
+      expect(7.♣️).to eq(CardGame::Card.from_string("7C"))
+
+      expect(10.spades).to eq(CardGame::Card.from_string("10S"))
+      expect(10.♤).to eq(CardGame::Card.from_string("10S"))
+      expect(10.♠︎).to eq(CardGame::Card.from_string("10S"))
+      expect(10.♠️︎).to eq(CardGame::Card.from_string("10S"))
+    end
+  end
+end

--- a/spec/unit/card_game/suit_spec.rb
+++ b/spec/unit/card_game/suit_spec.rb
@@ -1,0 +1,21 @@
+describe CardGame::Suit, aggregate_failures: true do
+  describe 'aliases' do
+    it 'points to the right things' do
+      expect(CardGame::Suit.♡).to eq(CardGame::Suit.hearts)
+      expect(CardGame::Suit.♥︎).to eq(CardGame::Suit.hearts)
+      expect(CardGame::Suit.♥️︎).to eq(CardGame::Suit.hearts)
+
+      expect(CardGame::Suit.♢).to eq(CardGame::Suit.diamonds)
+      expect(CardGame::Suit.♦︎).to eq(CardGame::Suit.diamonds)
+      expect(CardGame::Suit.♦️).to eq(CardGame::Suit.diamonds)
+
+      expect(CardGame::Suit.♧).to eq(CardGame::Suit.clubs)
+      expect(CardGame::Suit.♣︎).to eq(CardGame::Suit.clubs)
+      expect(CardGame::Suit.♣️).to eq(CardGame::Suit.clubs)
+
+      expect(CardGame::Suit.♤).to eq(CardGame::Suit.spades)
+      expect(CardGame::Suit.♠︎).to eq(CardGame::Suit.spades)
+      expect(CardGame::Suit.♠️︎).to eq(CardGame::Suit.spades)
+    end
+  end
+end


### PR DESCRIPTION
Because it wouldn't be an overengineered Ruby library without
1. patches to core classes (optional because we're not crazy)
2. unicode methods

@xaviershay 
